### PR TITLE
feat(pricing): reajuste 22/04/26 — frete 630/740, comissao fixa 145/170, diesel 6.12

### DIFF
--- a/services/business-rules.js
+++ b/services/business-rules.js
@@ -2,6 +2,7 @@
 import {
   GROUP_MOTORISTA, MOTORISTAS, VEICULOS, TERMINAIS,
   PEDAGIO, COMISSAO_PERCENTUAL, PRECO_LITRO_DIESEL,
+  getTerminalValor, getComissao, getPrecoLitroDiesel,
 } from './config.js'
 
 // Detect terminal from OCR text (tolerant matching — losing a freight is worse than a wrong terminal)
@@ -130,15 +131,16 @@ export function applyBusinessRules(ocr, chatJid, msgTimestamp) {
   result.terminal_key = termKey
   result.terminal_id = terminal.id
   result.terminal_nome = terminal.nome
-  result.valor_bruto = terminal.valor
+  // Pricing por data (cutoff 2026-04-22): novos valores 630/740, senao 580/680
+  result.valor_bruto = getTerminalValor(termKey, result.data_frete)
 
   // Rule 5: Pedagio (DPW/Santos Brasil only)
   if (termKey === 'DPW' || termKey === 'SANTOS BRASIL') {
     result.pedagio = PEDAGIO
   }
 
-  // Rule 6: Commission 25%
-  result.comissao = Math.round(result.valor_bruto * COMISSAO_PERCENTUAL * 100) / 100
+  // Rule 6: Commission — a partir de 2026-04-22 vira FIXA (145/170); antes 25%
+  result.comissao = getComissao(termKey, result.valor_bruto, result.data_frete)
 
   // Rule 7: Net value
   result.valor_liquido = result.valor_bruto - result.comissao - result.pedagio
@@ -203,7 +205,9 @@ export function processAbastecimento(ocr, chatJid) {
   const litros = parseFloat(ocr.LITROS) || 0
   if (litros < 30 || litros > 999) return null
 
-  const valor = Math.round(litros * PRECO_LITRO_DIESEL * 100) / 100
+  const dataAbast = convertDateToISO(ocr.DATA) || new Date().toISOString().split('T')[0]
+  const precoLitro = getPrecoLitroDiesel(dataAbast)
+  const valor = Math.round(litros * precoLitro * 100) / 100
   const descParts = []
   if (!ocr.KM_ODOMETRO) descParts.push('SEM KM')
   descParts.push('PRECO ESTIMADO')
@@ -217,11 +221,11 @@ export function processAbastecimento(ocr, chatJid) {
     status: 'PENDENTE',
     veiculo_id,
     litros,
-    preco_litro: PRECO_LITRO_DIESEL,
+    preco_litro: precoLitro,
     valor,
     km_odometro: ocr.KM_ODOMETRO ? parseInt(ocr.KM_ODOMETRO) : null,
     descricao: descParts.join(' | '),
-    data: convertDateToISO(ocr.DATA) || new Date().toISOString().split('T')[0],
+    data: dataAbast,
   }
 }
 

--- a/services/config.js
+++ b/services/config.js
@@ -53,7 +53,7 @@ export const VEICULOS = {
   'FJR7887': '30c1d111-e62d-4595-8d5b-27e559c43551',
 }
 
-// Terminal config
+// Terminal config (valor = pre-cutoff; novos valores em TERMINAIS_V2)
 export const TERMINAIS = {
   'BTP': { id: '5618b9cf-386c-44b6-888a-9ec1d6f6a269', nome: 'Brasil Terminal Portuario', valor: 580 },
   'ECOPORTO': { id: 'd7e7dcb8-a731-45d3-93a4-bf735a3b5515', nome: 'EcoPorto', valor: 580 },
@@ -65,6 +65,53 @@ export const TERMINAIS = {
 export const PEDAGIO = 54.90
 export const COMISSAO_PERCENTUAL = 0.25
 export const PRECO_LITRO_DIESEL = 6.25
+
+// Reajuste de precos a partir de 2026-04-22 (inclusive)
+// Frete sobe R$50 (580->630 / 680->740). Comissao motorista vira FIXA (145/170) em vez de 25%.
+// Diesel cai para R$6,12.
+export const PRICING_CUTOFF_DATE = '2026-04-22'
+
+export const TERMINAL_VALOR_V2 = {
+  'BTP': 630,
+  'ECOPORTO': 630,
+  'NAO_DEFINIDO': 630,
+  'DPW': 740,
+  'SANTOS BRASIL': 740,
+}
+
+export const COMISSAO_FIXA_V2 = {
+  'BTP': 145,
+  'ECOPORTO': 145,
+  'NAO_DEFINIDO': 145,
+  'DPW': 170,
+  'SANTOS BRASIL': 170,
+}
+
+export const PRECO_LITRO_DIESEL_V2 = 6.12
+
+// Helpers: escolhem valores pela data do frete/abastecimento (YYYY-MM-DD)
+export function isNewPricing(dateStr) {
+  if (!dateStr) return false
+  return String(dateStr) >= PRICING_CUTOFF_DATE
+}
+
+export function getTerminalValor(terminalKey, dateStr) {
+  if (isNewPricing(dateStr) && TERMINAL_VALOR_V2[terminalKey] != null) {
+    return TERMINAL_VALOR_V2[terminalKey]
+  }
+  return TERMINAIS[terminalKey]?.valor ?? 0
+}
+
+export function getComissao(terminalKey, valorBruto, dateStr) {
+  if (isNewPricing(dateStr) && COMISSAO_FIXA_V2[terminalKey] != null) {
+    return COMISSAO_FIXA_V2[terminalKey]
+  }
+  return Math.round((valorBruto || 0) * COMISSAO_PERCENTUAL * 100) / 100
+}
+
+export function getPrecoLitroDiesel(dateStr) {
+  return isNewPricing(dateStr) ? PRECO_LITRO_DIESEL_V2 : PRECO_LITRO_DIESEL
+}
 
 // Easypanel (for Evolution container restart)
 export const EASYPANEL_HOST = process.env.EASYPANEL_HOST || 'https://u0otng.easypanel.host'

--- a/src/components/fretes/FreteDetail.tsx
+++ b/src/components/fretes/FreteDetail.tsx
@@ -103,7 +103,7 @@ export function FreteDetail({ frete }: FreteDetailProps) {
             <h4 className="text-sm font-semibold text-slate-700 mb-2">Valores</h4>
             <Row label="Valor Bruto" value={formatCurrency(frete.valor_bruto)} />
             <Row label="Pedágio" value={formatCurrency(frete.pedagio)} />
-            <Row label="Comissão (25%)" value={formatCurrency(frete.comissao)} />
+            <Row label="Comissão" value={formatCurrency(frete.comissao)} />
             <Row label="Valor Líquido" value={formatCurrency(frete.valor_liquido)} bold />
           </div>
 


### PR DESCRIPTION
## Mudanca solicitada pelo Thiago Paulino

Reajuste de precos vigente a partir de **2026-04-22 (hoje, inclusive)**.

### Valores novos
| Item | Antes | Depois |
|------|-------|--------|
| Frete BTP / ECOPORTO / NAO_DEFINIDO | R\$ 580 | **R\$ 630** |
| Frete DPW / Santos Brasil | R\$ 680 | **R\$ 740** |
| Comissao motorista (frete 630) | 25% (R\$ 145) | **R\$ 145 fixo** |
| Comissao motorista (frete 740) | 25% (R\$ 170) | **R\$ 170 fixo** |
| Diesel (preco/litro estimado) | R\$ 6,25 | **R\$ 6,12** |

### Impacto
- Thiago: **+R\$ 50 por frete** (bruto sobe, comissao fixa).
- Motorista: recebe **o mesmo** (R\$ 145 ou R\$ 170).
- Abastecimento: recalcula valor a R\$ 6,12/L pra tickets sem preco real.

### Compatibilidade
Cutoff por **data do frete / data do abastecimento**. Registros anteriores a 22/04 mantem valores antigos — reprocessamento nao muda historico.

## Implementacao

- `services/config.js`: adiciona `PRICING_CUTOFF_DATE`, `TERMINAL_VALOR_V2`, `COMISSAO_FIXA_V2`, `PRECO_LITRO_DIESEL_V2` + helpers `isNewPricing`, `getTerminalValor`, `getComissao`, `getPrecoLitroDiesel`
- `services/business-rules.js`: `applyBusinessRules` usa helpers por data; `processAbastecimento` idem
- `src/components/fretes/FreteDetail.tsx`: label "Comissao (25%)" vira "Comissao" (agora pode ser fixa)

## Test plan
- [x] Validacao local node: BTP/ECO/NAO 21/04 → 580@145 | 22/04 → 630@145
- [x] DPW/SB 21/04 → 680@170 | 22/04 → 740@170
- [x] Diesel 21/04 → 6.25 | 22/04 → 6.12
- [ ] Apos deploy: enviar frete de teste hoje e confirmar bruto 630/740 + comissao 145/170 no dashboard
- [ ] Enviar ticket abastecimento e confirmar valor = litros * 6.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)