### PR TITLE
feat(vazio): aceitar frete sem container como tipo_frete=VAZIO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpaulino-gestao-fretes",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpaulino-gestao-fretes",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.49.1",
         "express": "^5.2.1",

--- a/services/business-rules.js
+++ b/services/business-rules.js
@@ -79,10 +79,12 @@ function applyBusinessDayCutoff(dateStr, msgTimestamp) {
 // msgTimestamp: ISO string or Date of when the WhatsApp photo was sent (fallback for bad OCR dates)
 export function applyBusinessRules(ocr, chatJid, msgTimestamp) {
   const rawDate = convertDateToISO(ocr.DATA) || new Date().toISOString().split('T')[0]
+  const containerRaw = (ocr.CONTAINER || '').trim()
   const result = {
     ignorado: false,
     erro_validacao: null,
-    container: ocr.CONTAINER || '',
+    container: containerRaw,
+    tipo_frete: containerRaw ? 'VIRA' : 'VAZIO',
     motorista_nome: null,
     motorista_id: null,
     placa: null,

--- a/services/gemini-ocr.js
+++ b/services/gemini-ocr.js
@@ -9,7 +9,7 @@ const TICKET_PROMPT = `You are an OCR specialist analyzing freight ticket images
 
 Analyze this image and extract:
 1. TIPO_DOCUMENTO: "TICKET_FRETE" (freight ticket) or "OUTRO" (other/invalid)
-2. CONTAINER: Container/shipment number (alphanumeric, e.g. OOLU6283142)
+2. CONTAINER: Container/shipment number (alphanumeric, e.g. OOLU6283142). MAY BE NULL on empty-container trips (see below).
 3. MOTORISTA: Driver name (UPPERCASE)
 4. PLACA: Vehicle license plate (Brazilian format, field may say "Cavalo")
 5. DATA: Date in DD/MM/YYYY format. IMPORTANT: The year is ALWAYS 2026. If the year appears faded, truncated, or ambiguous, use 2026. If handwritten American format (M/D/YYYY), convert. Never return years other than 2026.
@@ -17,14 +17,18 @@ Analyze this image and extract:
 7. SEQUENCIA: Sequence number (integer 1-50). Careful with similar handwritten digits (1 vs 7, 4 vs 9). If not present, return null.
 
 IMPORTANT: Freight tickets come in MULTIPLE formats:
-- Classic: has sequence number, weight, etc.
+- Classic: has sequence number, weight, container number.
 - Positioning ticket: has Bloco, Quadra, Posicao fields (Santos Brasil style).
 - Gate/entry ticket: has "Bem Vindo", driver name, plate, container.
-ALL of these are valid TICKET_FRETE if they contain a container number and a terminal/port logo.
-Only classify as OUTRO if the image has NO container number and is clearly not port-related.
+- Empty-container trip ("frete VAZIO"): terminal pass/receipt (e.g. Santos Brasil "DADOS DE PASSAGEM" with "CONTEINERES" header but EMPTY list, or any port pass with motorista + cavalo + entrada/saida and NO container number listed). The driver is positioning/returning an empty container, no container number is printed. CONTAINER must be null in this case.
 
-Return ONLY valid JSON, no markdown. Example:
-{"TIPO_DOCUMENTO":"TICKET_FRETE","CONTAINER":"OOLU6283142","MOTORISTA":"VALTER","PLACA":"GFR6A86","DATA":"12/03/2026","LOCAL":"DPW","SEQUENCIA":5}
+ALL of these are valid TICKET_FRETE as long as they show a port/terminal logo + driver/plate. Container being missing is OK for VAZIO trips — DO NOT classify as OUTRO just because there is no container number.
+
+Only classify as OUTRO if the image is clearly not a port document (pump display, random photo, fuel ticket, food receipt, etc).
+
+Return ONLY valid JSON, no markdown. Examples:
+- Cheio:  {"TIPO_DOCUMENTO":"TICKET_FRETE","CONTAINER":"OOLU6283142","MOTORISTA":"VALTER","PLACA":"GFR6A86","DATA":"12/03/2026","LOCAL":"DPW","SEQUENCIA":5}
+- Vazio:  {"TIPO_DOCUMENTO":"TICKET_FRETE","CONTAINER":null,"MOTORISTA":"VALTER","PLACA":"GFR6A86","DATA":"26/04/2026","LOCAL":"SANTOS BRASIL","SEQUENCIA":null}
 
 If not a valid freight ticket: {"TIPO_DOCUMENTO":"OUTRO"}`
 

--- a/services/tp-ocr-pipeline.js
+++ b/services/tp-ocr-pipeline.js
@@ -84,20 +84,17 @@ export async function processWebhookMessage(body) {
       return
     }
 
-    // Step 7: Validate container before insert (empty container = ghost frete)
-    if (!frete.container || frete.container.trim() === '') {
-      console.warn(`[OCR] Rejected: empty container from ${msg.chat_jid}`)
-      await db.patch('tp_mensagens_raw', rawFilter, {
-        status: 'ERRO',
-        ocr_resultado: { ...ocr, erro: 'Container vazio, frete rejeitado' },
-      })
-      alertError('Frete REJEITADO', `Container vazio.\nMotorista: ${GROUP_MOTORISTA[msg.chat_jid]?.motorista || msg.chat_jid}\nMsg: ${msg.msg_id}`)
-      return
+    // Step 7: Container vazio = saida sem container (posicionamento/retirada de vazio).
+    // Aceita como tipo_frete=VAZIO em vez de rejeitar.
+    const isVazio = frete.tipo_frete === 'VAZIO'
+    if (isVazio) {
+      console.log(`[OCR] Frete VAZIO (sem container) from ${GROUP_MOTORISTA[msg.chat_jid]?.motorista || msg.chat_jid}`)
     }
 
     // INSERT tp_fretes
     const fretePayload = {
       container: frete.container,
+      tipo_frete: frete.tipo_frete,
       motorista_id: frete.motorista_id,
       veiculo_id: frete.veiculo_id,
       terminal_id: frete.terminal_id,
@@ -124,11 +121,16 @@ export async function processWebhookMessage(body) {
     })
 
     // Step 10: Push notification (best-effort)
-    sendPush(frete.motorista_nome, frete.terminal_nome, frete.container, frete.valor_liquido)
+    const pushLabel = frete.container || 'VAZIO'
+    sendPush(frete.motorista_nome, frete.terminal_nome, pushLabel, frete.valor_liquido)
 
-    // Step 11: WhatsApp confirmation (tracked, retries inline, alerts on failure)
-    // RECOVERY_MODE: skip WhatsApp echo during bulk zombie recovery to avoid flooding driver groups
-    if (process.env.RECOVERY_MODE === 'true') {
+    // Step 11: WhatsApp confirmation (tracked, retries inline, alerts on failure).
+    // Frete VAZIO nao tem container pra ecoar — marca como confirmado e segue.
+    if (isVazio) {
+      await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_enviada: true, confirmacao_erro: 'VAZIO: sem confirmacao' })
+      console.log(`[OCR] VAZIO: skipped WhatsApp confirmation`)
+    } else if (process.env.RECOVERY_MODE === 'true') {
+      // RECOVERY_MODE: skip WhatsApp echo during bulk zombie recovery to avoid flooding driver groups
       await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_enviada: true, confirmacao_erro: 'RECOVERY_MODE: skipped' })
       console.log(`[OCR] RECOVERY_MODE: skipped WhatsApp confirmation for ${frete.container}`)
     } else {
@@ -146,7 +148,7 @@ export async function processWebhookMessage(body) {
     }
     }
 
-    console.log(`[OCR] Done: ${frete.container} ${frete.motorista_nome} R$${frete.valor_liquido}`)
+    console.log(`[OCR] Done: ${pushLabel} ${frete.motorista_nome} R$${frete.valor_liquido}`)
 
   } catch (err) {
     console.error(`[OCR] Pipeline error for ${msg.msg_id}:`, err.message)
@@ -210,20 +212,23 @@ export async function reprocessRawRecord(record) {
     return { status: 'OK', frete_id: record.frete_id, skipped_insert: true }
   }
 
-  // Dedup: check by container + data_frete
-  const existing = await db.query('tp_fretes',
-    `select=id&container=eq.${encodeURIComponent(frete.container)}&data_frete=eq.${frete.data_frete}&limit=1`,
-    'return=representation'
-  ).catch(() => [])
-  if (existing.length > 0) {
-    console.log(`[Reprocess] Skipping INSERT, duplicate container ${frete.container} on ${frete.data_frete}: ${existing[0].id}`)
-    await db.patch('tp_mensagens_raw', rawFilter, { status: 'OK', frete_id: existing[0].id, ocr_resultado: ocr })
-    return { status: 'OK', frete_id: existing[0].id, skipped_insert: true }
+  // Dedup: check by container + data_frete (skip for VAZIO — sem container nao da pra dedupar com seguranca)
+  if (frete.container) {
+    const existing = await db.query('tp_fretes',
+      `select=id&container=eq.${encodeURIComponent(frete.container)}&data_frete=eq.${frete.data_frete}&limit=1`,
+      'return=representation'
+    ).catch(() => [])
+    if (existing.length > 0) {
+      console.log(`[Reprocess] Skipping INSERT, duplicate container ${frete.container} on ${frete.data_frete}: ${existing[0].id}`)
+      await db.patch('tp_mensagens_raw', rawFilter, { status: 'OK', frete_id: existing[0].id, ocr_resultado: ocr })
+      return { status: 'OK', frete_id: existing[0].id, skipped_insert: true }
+    }
   }
 
   // INSERT frete
   const freteRecord = await db.insert('tp_fretes', {
     container: frete.container,
+    tipo_frete: frete.tipo_frete,
     motorista_id: frete.motorista_id,
     veiculo_id: frete.veiculo_id,
     terminal_id: frete.terminal_id,
@@ -243,17 +248,22 @@ export async function reprocessRawRecord(record) {
     ocr_resultado: ocr,
   })
 
-  sendPush(frete.motorista_nome, frete.terminal_nome, frete.container, frete.valor_liquido)
+  const reprocessPushLabel = frete.container || 'VAZIO'
+  sendPush(frete.motorista_nome, frete.terminal_nome, reprocessPushLabel, frete.valor_liquido)
 
-  try {
-    const confirmResult = await confirmaFrete(frete.container, msg.chat_jid)
-    if (confirmResult.success) {
-      await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_enviada: true })
-    } else {
-      await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_erro: confirmResult.error || 'unknown' })
+  if (frete.tipo_frete === 'VAZIO') {
+    await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_enviada: true, confirmacao_erro: 'VAZIO: sem confirmacao' })
+  } else {
+    try {
+      const confirmResult = await confirmaFrete(frete.container, msg.chat_jid)
+      if (confirmResult.success) {
+        await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_enviada: true })
+      } else {
+        await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_erro: confirmResult.error || 'unknown' })
+      }
+    } catch (confirmErr) {
+      await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_erro: confirmErr.message?.substring(0, 500) }).catch(() => {})
     }
-  } catch (confirmErr) {
-    await db.patch('tp_fretes', `id=eq.${freteRecord.id}`, { confirmacao_erro: confirmErr.message?.substring(0, 500) }).catch(() => {})
   }
 
   return { status: 'OK', frete_id: freteRecord.id }

--- a/src/components/fretes/FreteCard.tsx
+++ b/src/components/fretes/FreteCard.tsx
@@ -32,6 +32,9 @@ export function FreteCard({ frete }: FreteCardProps) {
             <Badge variant={statusVariant[frete.status as keyof typeof statusVariant] || 'default'}>
               {frete.status}
             </Badge>
+            {frete.tipo_frete === 'VAZIO' && (
+              <Badge variant="warning">VAZIO</Badge>
+            )}
           </div>
           <div className="flex items-center gap-3 text-sm text-slate-500 mb-1">
             <span>{frete.tp_terminais?.codigo || 'N/A'}</span>
@@ -47,9 +50,11 @@ export function FreteCard({ frete }: FreteCardProps) {
           <div className="flex items-center gap-3 text-sm">
             <span className="text-slate-400">{formatDate(frete.data_frete)}</span>
             <span className="text-slate-400 font-semibold">{formatTime(frete.created_at)}</span>
-            {frete.container && (
+            {frete.container ? (
               <span className="text-slate-400 font-mono text-xs">{frete.container}</span>
-            )}
+            ) : frete.tipo_frete === 'VAZIO' ? (
+              <span className="text-amber-600 font-mono text-xs">sem container</span>
+            ) : null}
           </div>
         </div>
         <div className="flex items-center gap-2 ml-2">


### PR DESCRIPTION
## Summary
- Frete sem container deixa de ser rejeitado e passa a ser cadastrado como `tipo_frete=VAZIO` (saida vazia / posicionamento / retirada de vazio).
- Pipeline normal + reprocess (safety-net) ambos respeitam a nova regra. Confirmacao WhatsApp e dedup por container sao puladas no caso VAZIO.
- Gemini prompt atualizado pra reconhecer passes sem container (Santos Brasil "DADOS DE PASSAGEM" sem CONTEINERES, etc) como TICKET_FRETE valido com CONTAINER=null.
- UI: badge "VAZIO" e label "sem container" no `FreteCard`.

## Contexto
Marco identificou que tinha frete recente do VALTER ignorado por ser saida vazia. Antes do commit `7bb0890` o pipeline rejeitava com status ERRO. Caso real: msg `ACD699368B3DB95A31C15A9E262DF1A9` (VALTER, GFR6A86, Santos Brasil, 26/04 04:53 BRT, ticket de passagem sem container) — entrou via `reprocessRawRecord` (que nao tinha o check) e ficou como `tipo_frete=VIRA, container=""`.

## Backfill manual
Frete `70d73ebf-1336-4906-b632-774522497c19` corrigido de `tipo_frete=VIRA` para `VAZIO` via PATCH direto no Supabase (`tp_fretes`). Mantidos valor_bruto R$740, comissao R$170, pedagio R$54,90, valor_liquido R$515,10 (mesma viagem, terminal Santos Brasil pos-22/04).

## Test plan
- [x] `npm run build` (tsc + vite) verde
- [x] UPDATE no Supabase confirmado (frete VALTER ja aparece como VAZIO)
- [ ] Pos-merge: validar no app que badge "VAZIO" aparece no frete VALTER 25/04
- [ ] Proximo ticket vazio que chegar via webhook deve cair como `tipo_frete=VAZIO` automaticamente
- [ ] Verificar Gemini classificando ticket Santos Brasil "DADOS DE PASSAGEM" sem CONTEINERES como TICKET_FRETE (nao mais OUTRO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)