### PR TITLE
feat(backfill): cron 03:00 BRT recupera gaps Evolution -> Railway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-05-20
+
+- `feat(backfill)`: cron diario `tp-backfill.js` 03:00 BRT compara mensagens da Evolution PG store vs `tp_mensagens_raw` nas ultimas 24h e re-injeta gaps via pipeline. Idempotente (dedup por msg_id + UNIQUE constraint). Endpoint manual `POST /api/tp/backfill` (header `x-api-key`).
+- Motivacao: 19/05 downtime provider-wide Railway ~6h derrubou webhook Evolution -> Railway. 5 fretes ficaram fora de `tp_mensagens_raw` e foram recuperados manualmente em 20/05. Cron resolve sozinho na proxima madrugada caso aconteca de novo. Notifica Marco no zap pessoal so se atuou.
+- Reaproveita padrao de recovery validado em `tp-zombie-monitor.js` (`findMessages` + `getBase64FromMedia` + `processWebhookMessage`). Roda antes do safety-net (06:00 BRT) pra registros recem-injetados ja passarem pela rede de protecao.
+
 ## 2026-05-04
 
 - `feat(recovery)`: script CLI standalone pra recovery pos-zombie Evolution (`scripts/tp-recovery.js` + wrapper `tp-recovery.sh`).

--- a/server.js
+++ b/server.js
@@ -189,6 +189,21 @@ app.post('/api/tp/reprocess', async (req, res) => {
   res.json({ ok: true, stats })
 })
 
+// Manual backfill trigger: scan Evolution vs tp_mensagens_raw, inject gaps
+app.post('/api/tp/backfill', async (req, res) => {
+  const apiKey = req.headers['x-api-key'] || req.query.key
+  if (apiKey !== PUSH_API_KEY) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+  try {
+    const { runBackfill } = await import('./services/tp-backfill.js')
+    const stats = await runBackfill()
+    res.json({ ok: true, stats })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 // Retry failed confirmations
 app.post('/api/tp/retry-confirmacoes', async (req, res) => {
   const apiKey = req.headers['x-api-key'] || req.query.key

--- a/services/tp-backfill.js
+++ b/services/tp-backfill.js
@@ -31,144 +31,162 @@ export async function runBackfill() {
   const sinceMs = Date.now() - LOOKBACK_HOURS * 60 * 60 * 1000
   const sinceUnix = Math.floor(sinceMs / 1000)
 
+  // Ativa RECOVERY_MODE pra esta execucao: pipeline NAO envia confirmacao no grupo
+  // (motorista nao recebe ping 03h da manha). Ainda marca confirmacao_enviada=true
+  // com confirmacao_erro='RECOVERY_MODE: skipped' no tp_fretes pra rastrear.
+  // Restaurado no finally.
+  const recoveryModePrev = process.env.RECOVERY_MODE
+  process.env.RECOVERY_MODE = 'true'
+
   const recovered = []
   const skipped = []
   const failed = []
   const groupJids = Object.keys(GROUP_MOTORISTA)
 
-  for (const jid of groupJids) {
-    const motorista = GROUP_MOTORISTA[jid]?.motorista || jid
-    try {
-      // 1. Pega mensagens da Evolution PG store no periodo (MongoDB-style $gte)
-      const result = await findMessages(
-        {
-          key: { remoteJid: jid },
-          messageTimestamp: { $gte: sinceUnix },
-        },
-        1,
-        100,
-      )
-      const records = result?.messages?.records || result?.messages || []
-      const imageMessages = records.filter((m) => m.message?.imageMessage && m.key?.id && !m.key?.fromMe)
-      if (imageMessages.length === 0) {
-        console.log(`[Backfill] ${motorista}: nenhuma imagem nas ultimas ${LOOKBACK_HOURS}h`)
-        continue
-      }
+  try {
+    for (const jid of groupJids) {
+      const motorista = GROUP_MOTORISTA[jid]?.motorista || jid
+      try {
+        // 1. Pega mensagens da Evolution PG store no periodo (MongoDB-style $gte)
+        const result = await findMessages(
+          {
+            key: { remoteJid: jid },
+            messageTimestamp: { $gte: sinceUnix },
+          },
+          1,
+          100,
+        )
+        const records = result?.messages?.records || result?.messages || []
+        const imageMessages = records.filter((m) => m.message?.imageMessage && m.key?.id && !m.key?.fromMe)
+        if (imageMessages.length === 0) {
+          console.log(`[Backfill] ${motorista}: nenhuma imagem nas ultimas ${LOOKBACK_HOURS}h`)
+          continue
+        }
 
-      console.log(`[Backfill] ${motorista}: ${imageMessages.length} imagens na evolution nas ultimas ${LOOKBACK_HOURS}h`)
+        console.log(`[Backfill] ${motorista}: ${imageMessages.length} imagens na evolution nas ultimas ${LOOKBACK_HOURS}h`)
 
-      // Safety cap: se Evolution retorna muita coisa nesse grupo, algo ta errado.
-      if (imageMessages.length > MAX_GAPS_PER_GROUP * 5) {
-        const reason = `cap excedido: ${imageMessages.length} imagens (esperado <= ${MAX_GAPS_PER_GROUP * 5})`
-        console.warn(`[Backfill] ${motorista}: ${reason}, pulando`)
-        failed.push({ jid, reason })
-        continue
-      }
+        // Safety cap: se Evolution retorna muita coisa nesse grupo, algo ta errado.
+        if (imageMessages.length > MAX_GAPS_PER_GROUP * 5) {
+          const reason = `cap excedido: ${imageMessages.length} imagens (esperado <= ${MAX_GAPS_PER_GROUP * 5})`
+          console.warn(`[Backfill] ${motorista}: ${reason}, pulando`)
+          failed.push({ jid, reason })
+          continue
+        }
 
-      // 2. Pra cada imagem, verificar se ja existe em raw e injetar gap
-      let gapsInGroup = 0
-      for (const m of imageMessages) {
-        const msgId = m.key.id
+        // 2. Pra cada imagem, verificar se ja existe em raw e injetar gap
+        let gapsInGroup = 0
+        for (const m of imageMessages) {
+          const msgId = m.key.id
 
-        // 2a. Dedup
-        try {
-          const existing = await db.query(
-            'tp_mensagens_raw',
-            `select=msg_id,status&msg_id=eq.${encodeURIComponent(msgId)}&limit=1`,
-            'return=representation',
-          )
-          if (existing.length > 0) {
-            skipped.push({ msg_id: msgId, jid, status: existing[0].status })
+          // 2a. Dedup
+          try {
+            const existing = await db.query(
+              'tp_mensagens_raw',
+              `select=msg_id,status&msg_id=eq.${encodeURIComponent(msgId)}&limit=1`,
+              'return=representation',
+            )
+            if (existing.length > 0) {
+              skipped.push({ msg_id: msgId, jid, status: existing[0].status })
+              continue
+            }
+          } catch {}
+
+          // Atingiu cap de gaps neste grupo: para de injetar e sai do loop do grupo.
+          // (Marco investiga manual. Continuar iteraria as msgs restantes empilhando
+          // entradas duplicadas em `failed` sem nenhum proposito util.)
+          if (gapsInGroup >= MAX_GAPS_PER_GROUP) {
+            failed.push({ jid, reason: `MAX_GAPS_PER_GROUP=${MAX_GAPS_PER_GROUP} excedido neste grupo, demais msgs nao processadas` })
+            break
+          }
+
+          gapsInGroup++
+
+          // 2b. Pega base64 (pode ja vir embutido na response, senao baixa)
+          let base64 = m.message?.base64 || ''
+          if (!base64 && m.message) {
+            base64 = (await getBase64FromMedia(m.message).catch(() => null)) || ''
+          }
+
+          // 2c. Sem base64 -> inserir PENDENTE pro safety-net das 06:00 BRT pegar
+          if (!base64) {
+            try {
+              await db.insert('tp_mensagens_raw', {
+                msg_id: msgId,
+                chat_jid: jid,
+                sender_jid: m.key.participant || '',
+                timestamp_msg: new Date((m.messageTimestamp || sinceUnix) * 1000).toISOString(),
+                status: 'PENDENTE',
+                caption: m.message?.imageMessage?.caption || null,
+              })
+              failed.push({ msg_id: msgId, jid, reason: 'sem base64, marcado PENDENTE pro safety-net' })
+            } catch (insertErr) {
+              failed.push({ msg_id: msgId, jid, reason: insertErr.message })
+            }
             continue
           }
-        } catch {}
 
-        // Atingiu cap de gaps neste grupo: parar de injetar (Marco vai investigar)
-        if (gapsInGroup >= MAX_GAPS_PER_GROUP) {
-          failed.push({ jid, msg_id: msgId, reason: `MAX_GAPS_PER_GROUP=${MAX_GAPS_PER_GROUP} excedido` })
-          continue
-        }
-
-        gapsInGroup++
-
-        // 2b. Pega base64 (pode ja vir embutido na response, senao baixa)
-        let base64 = m.message?.base64 || ''
-        if (!base64 && m.message) {
-          base64 = (await getBase64FromMedia(m.message).catch(() => null)) || ''
-        }
-
-        // 2c. Sem base64 -> inserir PENDENTE pro safety-net das 06:00 BRT pegar
-        if (!base64) {
-          try {
-            await db.insert('tp_mensagens_raw', {
-              msg_id: msgId,
-              chat_jid: jid,
-              sender_jid: m.key.participant || '',
-              timestamp_msg: new Date((m.messageTimestamp || sinceUnix) * 1000).toISOString(),
-              status: 'PENDENTE',
-              caption: m.message?.imageMessage?.caption || null,
-            })
-            failed.push({ msg_id: msgId, jid, reason: 'sem base64, marcado PENDENTE pro safety-net' })
-          } catch (insertErr) {
-            failed.push({ msg_id: msgId, jid, reason: insertErr.message })
+          // 2d. Injetar via pipeline (mesmo caminho do webhook Evolution).
+          // RECOVERY_MODE=true acima -> pipeline NAO envia confirmacao no grupo.
+          const fakeWebhook = {
+            data: {
+              key: {
+                remoteJid: jid,
+                fromMe: false,
+                id: msgId,
+                participant: m.key.participant || '',
+              },
+              messageTimestamp: m.messageTimestamp || sinceUnix,
+              message: {
+                imageMessage: m.message.imageMessage,
+                base64,
+              },
+            },
           }
-          continue
-        }
+          try {
+            await processWebhookMessage(fakeWebhook)
+            recovered.push({ msg_id: msgId, jid })
+            console.log(`[Backfill] ${motorista}: ${msgId} injetada com sucesso`)
+          } catch (err) {
+            failed.push({ msg_id: msgId, jid, reason: err.message })
+          }
 
-        // 2d. Injetar via pipeline (mesmo caminho do webhook Evolution)
-        const fakeWebhook = {
-          data: {
-            key: {
-              remoteJid: jid,
-              fromMe: false,
-              id: msgId,
-              participant: m.key.participant || '',
-            },
-            messageTimestamp: m.messageTimestamp || sinceUnix,
-            message: {
-              imageMessage: m.message.imageMessage,
-              base64,
-            },
-          },
+          // Espacar Gemini OCR
+          await new Promise((r) => setTimeout(r, DELAY_BETWEEN_INJECTIONS_MS))
         }
-        try {
-          await processWebhookMessage(fakeWebhook)
-          recovered.push({ msg_id: msgId, jid })
-          console.log(`[Backfill] ${motorista}: ${msgId} injetada com sucesso`)
-        } catch (err) {
-          failed.push({ msg_id: msgId, jid, reason: err.message })
-        }
-
-        // Espacar Gemini OCR + WhatsApp confirmacao
-        await new Promise((r) => setTimeout(r, DELAY_BETWEEN_INJECTIONS_MS))
+      } catch (err) {
+        console.error(`[Backfill] ${motorista}: erro fatal:`, err.message)
+        failed.push({ jid, reason: err.message })
       }
-    } catch (err) {
-      console.error(`[Backfill] ${motorista}: erro fatal:`, err.message)
-      failed.push({ jid, reason: err.message })
     }
-  }
 
-  const stats = { recovered: recovered.length, skipped: skipped.length, failed: failed.length }
-  console.log('[Backfill] Done. Stats:', stats)
+    const stats = { recovered: recovered.length, skipped: skipped.length, failed: failed.length }
+    console.log('[Backfill] Done. Stats:', stats)
 
-  // Notificar Marco SO se backfill atuou ou teve falha real
-  // (skipped sozinho = scan normal, nao notifica)
-  if (recovered.length > 0 || failed.length > 0) {
-    const motoristasRecovered = {}
-    for (const r of recovered) {
-      const mn = GROUP_MOTORISTA[r.jid]?.motorista || r.jid
-      motoristasRecovered[mn] = (motoristasRecovered[mn] || 0) + 1
+    // Notificar Marco SO se backfill atuou ou teve falha real
+    // (skipped sozinho = scan normal, nao notifica)
+    if (recovered.length > 0 || failed.length > 0) {
+      const motoristasRecovered = {}
+      for (const r of recovered) {
+        const mn = GROUP_MOTORISTA[r.jid]?.motorista || r.jid
+        motoristasRecovered[mn] = (motoristasRecovered[mn] || 0) + 1
+      }
+      const lines = [`[T-Paulino Backfill diario]`]
+      if (recovered.length > 0) {
+        lines.push(`Recuperou ${recovered.length} frete(s) (confirmacao no grupo desabilitada - motoristas dormindo):`)
+        lines.push(Object.entries(motoristasRecovered).map(([k, v]) => `- ${k}: ${v}`).join('\n'))
+      }
+      if (failed.length > 0) {
+        lines.push(`Falhas: ${failed.length}`)
+        lines.push(failed.slice(0, 5).map((f) => `- ${f.msg_id?.substring(0, 12) || f.jid}: ${f.reason}`).join('\n'))
+      }
+      sendText(MARCO_WHATSAPP, lines.join('\n')).catch(() => {})
     }
-    const lines = [`[T-Paulino Backfill diario]`]
-    if (recovered.length > 0) {
-      lines.push(`Recuperou ${recovered.length} frete(s):`)
-      lines.push(Object.entries(motoristasRecovered).map(([k, v]) => `- ${k}: ${v}`).join('\n'))
-    }
-    if (failed.length > 0) {
-      lines.push(`Falhas: ${failed.length}`)
-      lines.push(failed.slice(0, 5).map((f) => `- ${f.msg_id?.substring(0, 12) || f.jid}: ${f.reason}`).join('\n'))
-    }
-    sendText(MARCO_WHATSAPP, lines.join('\n')).catch(() => {})
+    return stats
+  } finally {
+    // Restaura RECOVERY_MODE pro estado anterior (importante: webhook em paralelo
+    // nao deve herdar a flag, pois enviaria confirmacao = false fora de janela
+    // de backfill).
+    if (recoveryModePrev === undefined) delete process.env.RECOVERY_MODE
+    else process.env.RECOVERY_MODE = recoveryModePrev
   }
-  return stats
 }

--- a/services/tp-backfill.js
+++ b/services/tp-backfill.js
@@ -1,0 +1,174 @@
+// services/tp-backfill.js — Daily backfill against Evolution gaps
+//
+// Detecta imagens enviadas pelos motoristas nos grupos T-Paulino nas ultimas
+// 24h que NAO entraram em `tp_mensagens_raw` (gap de webhook por downtime
+// Railway, problema de rede, etc) e re-injeta cada uma via pipeline.
+//
+// Idempotente: UNIQUE(msg_id, chat_jid) em tp_mensagens_raw blinda duplicacao,
+// e ainda fazemos dedup explicito por msg_id antes de cada injecao.
+// Anti-loop: roda 1x ao dia. Mesmo gap detectado em 2 noites seguidas pula
+// a 2a (msg_id ja existira em raw apos 1a recovery).
+//
+// Reaproveita o padrao de recuperacao validado em `tp-zombie-monitor.js`
+// (post-zombie recovery). Diferenca: aqui roda preventivamente todo dia
+// independente de o zombie monitor ter disparado.
+//
+// Caso real: 19/05/2026 Railway provider-wide downtime ~6h, 5 fretes ficaram
+// fora de tp_mensagens_raw. Recuperados manualmente em 20/05. Esse cron impede
+// repeticao do trabalho manual.
+
+import * as db from './supabase.js'
+import { findMessages, getBase64FromMedia, sendText } from './evolution.js'
+import { processWebhookMessage } from './tp-ocr-pipeline.js'
+import { GROUP_MOTORISTA, MARCO_WHATSAPP } from './config.js'
+
+const LOOKBACK_HOURS = 24
+const DELAY_BETWEEN_INJECTIONS_MS = 2000
+const MAX_GAPS_PER_GROUP = 20  // safety cap: acima disso ha algo muito errado
+
+export async function runBackfill() {
+  console.log('[Backfill] Starting daily backfill scan...')
+  const sinceMs = Date.now() - LOOKBACK_HOURS * 60 * 60 * 1000
+  const sinceUnix = Math.floor(sinceMs / 1000)
+
+  const recovered = []
+  const skipped = []
+  const failed = []
+  const groupJids = Object.keys(GROUP_MOTORISTA)
+
+  for (const jid of groupJids) {
+    const motorista = GROUP_MOTORISTA[jid]?.motorista || jid
+    try {
+      // 1. Pega mensagens da Evolution PG store no periodo (MongoDB-style $gte)
+      const result = await findMessages(
+        {
+          key: { remoteJid: jid },
+          messageTimestamp: { $gte: sinceUnix },
+        },
+        1,
+        100,
+      )
+      const records = result?.messages?.records || result?.messages || []
+      const imageMessages = records.filter((m) => m.message?.imageMessage && m.key?.id && !m.key?.fromMe)
+      if (imageMessages.length === 0) {
+        console.log(`[Backfill] ${motorista}: nenhuma imagem nas ultimas ${LOOKBACK_HOURS}h`)
+        continue
+      }
+
+      console.log(`[Backfill] ${motorista}: ${imageMessages.length} imagens na evolution nas ultimas ${LOOKBACK_HOURS}h`)
+
+      // Safety cap: se Evolution retorna muita coisa nesse grupo, algo ta errado.
+      if (imageMessages.length > MAX_GAPS_PER_GROUP * 5) {
+        const reason = `cap excedido: ${imageMessages.length} imagens (esperado <= ${MAX_GAPS_PER_GROUP * 5})`
+        console.warn(`[Backfill] ${motorista}: ${reason}, pulando`)
+        failed.push({ jid, reason })
+        continue
+      }
+
+      // 2. Pra cada imagem, verificar se ja existe em raw e injetar gap
+      let gapsInGroup = 0
+      for (const m of imageMessages) {
+        const msgId = m.key.id
+
+        // 2a. Dedup
+        try {
+          const existing = await db.query(
+            'tp_mensagens_raw',
+            `select=msg_id,status&msg_id=eq.${encodeURIComponent(msgId)}&limit=1`,
+            'return=representation',
+          )
+          if (existing.length > 0) {
+            skipped.push({ msg_id: msgId, jid, status: existing[0].status })
+            continue
+          }
+        } catch {}
+
+        // Atingiu cap de gaps neste grupo: parar de injetar (Marco vai investigar)
+        if (gapsInGroup >= MAX_GAPS_PER_GROUP) {
+          failed.push({ jid, msg_id: msgId, reason: `MAX_GAPS_PER_GROUP=${MAX_GAPS_PER_GROUP} excedido` })
+          continue
+        }
+
+        gapsInGroup++
+
+        // 2b. Pega base64 (pode ja vir embutido na response, senao baixa)
+        let base64 = m.message?.base64 || ''
+        if (!base64 && m.message) {
+          base64 = (await getBase64FromMedia(m.message).catch(() => null)) || ''
+        }
+
+        // 2c. Sem base64 -> inserir PENDENTE pro safety-net das 06:00 BRT pegar
+        if (!base64) {
+          try {
+            await db.insert('tp_mensagens_raw', {
+              msg_id: msgId,
+              chat_jid: jid,
+              sender_jid: m.key.participant || '',
+              timestamp_msg: new Date((m.messageTimestamp || sinceUnix) * 1000).toISOString(),
+              status: 'PENDENTE',
+              caption: m.message?.imageMessage?.caption || null,
+            })
+            failed.push({ msg_id: msgId, jid, reason: 'sem base64, marcado PENDENTE pro safety-net' })
+          } catch (insertErr) {
+            failed.push({ msg_id: msgId, jid, reason: insertErr.message })
+          }
+          continue
+        }
+
+        // 2d. Injetar via pipeline (mesmo caminho do webhook Evolution)
+        const fakeWebhook = {
+          data: {
+            key: {
+              remoteJid: jid,
+              fromMe: false,
+              id: msgId,
+              participant: m.key.participant || '',
+            },
+            messageTimestamp: m.messageTimestamp || sinceUnix,
+            message: {
+              imageMessage: m.message.imageMessage,
+              base64,
+            },
+          },
+        }
+        try {
+          await processWebhookMessage(fakeWebhook)
+          recovered.push({ msg_id: msgId, jid })
+          console.log(`[Backfill] ${motorista}: ${msgId} injetada com sucesso`)
+        } catch (err) {
+          failed.push({ msg_id: msgId, jid, reason: err.message })
+        }
+
+        // Espacar Gemini OCR + WhatsApp confirmacao
+        await new Promise((r) => setTimeout(r, DELAY_BETWEEN_INJECTIONS_MS))
+      }
+    } catch (err) {
+      console.error(`[Backfill] ${motorista}: erro fatal:`, err.message)
+      failed.push({ jid, reason: err.message })
+    }
+  }
+
+  const stats = { recovered: recovered.length, skipped: skipped.length, failed: failed.length }
+  console.log('[Backfill] Done. Stats:', stats)
+
+  // Notificar Marco SO se backfill atuou ou teve falha real
+  // (skipped sozinho = scan normal, nao notifica)
+  if (recovered.length > 0 || failed.length > 0) {
+    const motoristasRecovered = {}
+    for (const r of recovered) {
+      const mn = GROUP_MOTORISTA[r.jid]?.motorista || r.jid
+      motoristasRecovered[mn] = (motoristasRecovered[mn] || 0) + 1
+    }
+    const lines = [`[T-Paulino Backfill diario]`]
+    if (recovered.length > 0) {
+      lines.push(`Recuperou ${recovered.length} frete(s):`)
+      lines.push(Object.entries(motoristasRecovered).map(([k, v]) => `- ${k}: ${v}`).join('\n'))
+    }
+    if (failed.length > 0) {
+      lines.push(`Falhas: ${failed.length}`)
+      lines.push(failed.slice(0, 5).map((f) => `- ${f.msg_id?.substring(0, 12) || f.jid}: ${f.reason}`).join('\n'))
+    }
+    sendText(MARCO_WHATSAPP, lines.join('\n')).catch(() => {})
+  }
+  return stats
+}

--- a/services/tp-crons.js
+++ b/services/tp-crons.js
@@ -5,6 +5,7 @@ import { runSafetyNet } from './tp-safety-net.js'
 import { runAbastecimentoScan } from './tp-abastecimento.js'
 import { retryFailedConfirmacoes } from './tp-confirma.js'
 import { runZombieMonitor } from './tp-zombie-monitor.js'
+import { runBackfill } from './tp-backfill.js'
 
 export function startCrons() {
   // v2-07: Healthcheck every 30 minutes
@@ -24,6 +25,14 @@ export function startCrons() {
     runSafetyNet().catch(err => console.error('[Cron] SafetyNet error:', err.message))
   }, { timezone: 'America/Sao_Paulo' })
   console.log('[Cron] SafetyNet scheduled: daily 06:00 BRT')
+
+  // Backfill daily at 03:00 BRT — recupera gaps do webhook Evolution -> Railway
+  // (downtime Railway, problemas de rede). Idempotente via UNIQUE(msg_id, chat_jid).
+  // Roda antes do SafetyNet pra que registros recem-injetados ja passem pela rede de protecao.
+  cron.schedule('0 3 * * *', () => {
+    runBackfill().catch(err => console.error('[Cron] Backfill error:', err.message))
+  }, { timezone: 'America/Sao_Paulo' })
+  console.log('[Cron] Backfill scheduled: daily 03:00 BRT')
 
   // Retry failed WhatsApp confirmations every 10 minutes
   cron.schedule('*/10 * * * *', () => {


### PR DESCRIPTION
## Contexto

Em 19/05/2026 o Railway teve downtime provider-wide ~6h (16:55 -> 22:50 BRT). Webhook Evolution -> Railway nao chegou durante a janela, e 5 fretes ficaram fora de `tp_mensagens_raw`. Recuperacao foi manual em 20/05 (ver doc do incidente).

## O que muda

Cron diario `tp-backfill.js` 03:00 BRT que:
1. `findMessages` na Evolution PG store por grupo T-Paulino nas ultimas 24h
2. Cruza com `tp_mensagens_raw` via `msg_id`
3. Pra cada gap, `getBase64FromMedia` + `processWebhookMessage` (mesmo path do webhook)

Endpoint manual: `POST /api/tp/backfill` com header `x-api-key: tp-push-2026` pra QA sob demanda.

## Idempotencia (cuidado com duplicacao)

- Dedup explicito por `msg_id` antes de cada injecao (SELECT em tp_mensagens_raw)
- `UNIQUE(msg_id, chat_jid)` no schema blinda race
- Roda 1x ao dia: mesmo gap em 2 noites pula a 2a (msg_id ja existe apos recovery da 1a)

## Anti-loop

- `MAX_GAPS_PER_GROUP = 20`: se 1 grupo tem mais que isso de gap (ex: pipeline quebrado dias), nao injeta e marca como falha pra investigar manual
- Se sem base64, insere `PENDENTE` em vez de tentar repetidamente — safety-net das 06:00 BRT pega depois
- Roda em sequencia (nao paralelo), 2s entre injecoes pra nao saturar Gemini OCR

## Reaproveita padrao validado

Baseia em `recoverMessagesFromZombie` do `tp-zombie-monitor.js` (usado em 09/04, 11/04, 14/05). Diferenca: roda preventivamente todo dia, sem depender do zombie monitor disparar.

## Quando NAO atua

- Evolution-zombie de fato: se a Evolution nao recebeu a msg, ela tambem nao tem ela no PG store. Esse caso continua dependendo do zombie monitor + daemon WhatsApp local.
- Esse PR cobre **gap Railway-down com Evolution funcionando** (caso 19/05).

## Notificacao

Envia WhatsApp pro Marco SO se atuou ou teve falha (skipped sozinho = scan normal, silencioso).

## Test plan

- [ ] Merge para `main` -> Railway auto-deploy
- [ ] `curl -X POST https://tpaulino-gestao-fretes-production.up.railway.app/api/tp/backfill -H "x-api-key: tp-push-2026"` no horario normal: esperar `recovered: 0, skipped: N` (todas msgs ja em raw)
- [ ] Confirmar Discord/zap nao vem nenhum alerta (so atua se gap real)
- [ ] Aguardar primeira execucao 21/05 03:00 BRT, ver logs Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)