### PR TITLE
fix(ocr): retentar 403 transitorio do preview de enforcement do Gemini

### DIFF
--- a/services/gemini-ocr.js
+++ b/services/gemini-ocr.js
@@ -67,6 +67,12 @@ If not an S-10 ticket: {"TIPO_DOCUMENTO":"OUTRO"}`
 const MAX_RETRIES = 3
 const RETRY_CODES = new Set([429, 500, 502, 503, 529])
 
+// 403 transitório do "preview" do enforcement de chaves do Google (jun/2026): a chave JÁ esta
+// restrita a Gemini API, mas durante o preview o Google rejeita uma fracao das chamadas de forma
+// intermitente. Retentar SO esse caso, identificado pela mensagem. Um 403 real (chave revogada/
+// invalida/sem permissao) continua falhando rapido, sem loop de retry inutil.
+const TRANSIENT_403_RE = /temporary service disruptions|unrestricted key|preview of the enforcement/i
+
 async function callGemini(base64, prompt) {
   let lastError
 
@@ -93,13 +99,17 @@ async function callGemini(base64, prompt) {
         const body = await res.text()
         lastError = new Error(`Gemini OCR: ${res.status} ${body}`)
 
-        if (RETRY_CODES.has(res.status) && attempt < MAX_RETRIES) {
+        const retryable = RETRY_CODES.has(res.status) ||
+          (res.status === 403 && TRANSIENT_403_RE.test(body))
+        if (retryable && attempt < MAX_RETRIES) {
           const delay = Math.min(2000 * Math.pow(2, attempt - 1), 15000)
           console.warn(`[Gemini] ${res.status} on attempt ${attempt}/${MAX_RETRIES}, retrying in ${delay}ms`)
           if (attempt >= 2) alertWarning('Gemini retry', `Status ${res.status} na tentativa ${attempt}/${MAX_RETRIES}`)
           await new Promise(r => setTimeout(r, delay))
           continue
         }
+        // status HTTP definitivo (403 real de chave invalida, 400, 404...): nao reentrar no loop
+        if (!retryable) lastError.fatal = true
         throw lastError
       }
 
@@ -116,6 +126,7 @@ async function callGemini(base64, prompt) {
       }
     } catch (err) {
       lastError = err
+      if (err.fatal) throw err // erro HTTP definitivo: falha rapido, sem retentar
       if (err.name === 'TimeoutError' && attempt < MAX_RETRIES) {
         console.warn(`[Gemini] Timeout on attempt ${attempt}/${MAX_RETRIES}, retrying`)
         continue


### PR DESCRIPTION
## Contexto

Os grupos T-Paulino "pararam de funcionar" de forma intermitente: comprovantes com foto deixavam de ser lidos.

Diagnostico (18/06):
- A instancia Evolution (`marcofassa`) **nao caiu** — webhook disparando, mensagens chegando, HTTP 200.
- A chave Gemini (compartilhada com o repo da Dra Andressa, projeto GCP `operacoes-internas`) **ja esta corretamente restrita** a Gemini API (`generativelanguage`), que e exatamente o que o enforcement de 19/06/2026 exige. Nao e candidata a corte.
- Mesmo assim, durante o **preview** do enforcement o Google rejeita uma fracao das chamadas com `403 PERMISSION_DENIED` ("temporary service disruptions ... unrestricted keys ... preview of the enforcement"). Outros devs relatam o mesmo no [forum do Google](https://discuss.ai.google.dev/t/email-about-secure-your-gemini-api-access-by-jun-19-2026-seems-wrong/171046). E intermitente: a maioria das chamadas passa (10/10 em teste manual; OCR processou fretes normalmente as 13:51 e 14:57).

O problema real do nosso lado: o pipeline tratava `403` como erro **fatal** e **descartava o comprovante** (perda de informacao de frete) num pisco de instabilidade.

## O que muda

`services/gemini-ocr.js`:
- O `403` transitorio do preview (identificado pela mensagem) passa a ser **retentado com backoff**, junto dos 5xx/429 que ja eram.
- `403` real (chave invalida/revogada) e demais 4xx definitivos passam a **falhar na 1a tentativa** (flag `fatal`), em vez de reentrar no loop 3x como acontecia (o `catch` generico retentava qualquer erro nao-timeout).

Diff: +12/-1.

## Testes

Smoke com `fetch` mockado contra o codigo real (4 cenarios, ALL PASS):

| Cenario | Esperado | Resultado |
|---|---|---|
| 403-preview na 1a, 200 na 2a | retenta com backoff e resolve | PASS (2 calls, 2s) |
| 403-real (chave invalida) | falha na 1a, sem retry | PASS (1 call, 0ms) |
| 503 | segue retentando (nao-regressao) | PASS (2 calls) |
| 403-preview persistente | esgota MAX_RETRIES e lanca (sem loop) | PASS (3 calls) |

## Risco

Baixo. Mudanca isolada na funcao de chamada do Gemini. Comportamento de sucesso e de 5xx inalterado. Pior caso do novo retry: +6s de backoff (2s+4s) antes de desistir de um 403 que persista nas 3 tentativas — no episodio atual a taxa de 403 e baixa, entao na pratica resolve na 1a ou 2a.
