### PR TITLE
fix(pricing): Santos Brasil 680 vs 740 - precificar depois da correcao de data

### DIFF
--- a/services/business-rules.js
+++ b/services/business-rules.js
@@ -133,19 +133,16 @@ export function applyBusinessRules(ocr, chatJid, msgTimestamp) {
   result.terminal_key = termKey
   result.terminal_id = terminal.id
   result.terminal_nome = terminal.nome
-  // Pricing por data (cutoff 2026-04-22): novos valores 630/740, senao 580/680
-  result.valor_bruto = getTerminalValor(termKey, result.data_frete)
 
-  // Rule 5: Pedagio (DPW/Santos Brasil only)
+  // Rule 5: Pedagio (DPW/Santos Brasil only) — depende so do terminal, nao da data
   if (termKey === 'DPW' || termKey === 'SANTOS BRASIL') {
     result.pedagio = PEDAGIO
   }
 
-  // Rule 6: Commission — a partir de 2026-04-22 vira FIXA (145/170); antes 25%
-  result.comissao = getComissao(termKey, result.valor_bruto, result.data_frete)
-
-  // Rule 7: Net value
-  result.valor_liquido = result.valor_bruto - result.comissao - result.pedagio
+  // NOTA (fix 2026-07-10): valor_bruto/comissao/valor_liquido sao calculados
+  // DEPOIS da Regra 8. A Regra 8 pode corrigir uma data OCR fora de range pro
+  // timestamp da mensagem; precificar antes disso deixava fretes pos-cutoff com
+  // valor pre-cutoff (Santos Brasil ~50% a 680 em vez de 740). Ver Rule 4b abaixo.
 
   // Rule 8: Date validation (within 7 days past / 7 days future)
   // If OCR date is out of range, fallback to message timestamp (when photo was sent).
@@ -172,6 +169,12 @@ export function applyBusinessRules(ocr, chatJid, msgTimestamp) {
       }
     }
   }
+
+  // Rule 4b/6/7: Pricing — calculado AQUI, depois da Regra 8, pra usar a
+  // data_frete FINAL (fix 2026-07-10 do subfaturamento Santos Brasil 680 vs 740).
+  result.valor_bruto = getTerminalValor(termKey, result.data_frete)
+  result.comissao = getComissao(termKey, result.valor_bruto, result.data_frete)
+  result.valor_liquido = result.valor_bruto - result.comissao - result.pedagio
 
   // Rule 9: Sequence 1-50
   if (result.sequencia < 1 || result.sequencia > 50) {

--- a/services/test-pricing-date-order.js
+++ b/services/test-pricing-date-order.js
@@ -1,0 +1,39 @@
+// Test: pricing precisa usar a data_frete FINAL (depois da Regra 8 corrigir a data).
+// Repro do bug Santos Brasil 680 vs 740: OCR le data pre-cutoff fora de range,
+// a Regra 8 corrige pro timestamp da msg (pos-cutoff), e o valor deve virar 740.
+// Rodar: node services/test-pricing-date-order.js
+import assert from 'node:assert'
+import { applyBusinessRules } from './business-rules.js'
+
+const chatJid = '120363039509825419@g.us' // ALESSANDRO (grupo valido)
+const msgTsPosCutoff = '2026-07-10T15:00:00Z' // 12h BRT, pos-cutoff, dentro do range
+
+// Caso 1 (o bug): OCR leu data pre-cutoff E fora de range -> Regra 8 corrige -> deve ser 740
+const bug = applyBusinessRules({
+  TIPO_DOCUMENTO: 'TICKET_FRETE',
+  DATA: '15/01/2026',       // pre-cutoff + fora do range de 7 dias (hoje ~jul)
+  CONTAINER: 'ABCD1234567', // com container => VIRA
+  LOCAL: 'SANTOS BRASIL',
+  SEQUENCIA: 5,
+}, chatJid, msgTsPosCutoff)
+assert.strictEqual(bug.data_frete, '2026-07-10',
+  `Regra 8 deveria corrigir a data pro timestamp da msg, veio ${bug.data_frete}`)
+assert.strictEqual(bug.valor_bruto, 740,
+  `BUG: frete pos-cutoff deveria valer 740, veio ${bug.valor_bruto}`)
+assert.strictEqual(bug.comissao, 170,
+  `comissao fixa v2 deveria ser 170, veio ${bug.comissao}`)
+assert.strictEqual(bug.valor_liquido, 740 - 170 - 54.9,
+  `liquido inconsistente: ${bug.valor_liquido}`)
+
+// Caso 2 (sanidade): OCR le data pos-cutoff correta -> 740 (sem depender da Regra 8)
+const limpo = applyBusinessRules({
+  TIPO_DOCUMENTO: 'TICKET_FRETE',
+  DATA: '10/07/2026',
+  CONTAINER: 'ABCD1234567',
+  LOCAL: 'SANTOS BRASIL',
+  SEQUENCIA: 5,
+}, chatJid, msgTsPosCutoff)
+assert.strictEqual(limpo.valor_bruto, 740,
+  `pos-cutoff limpo deveria ser 740, veio ${limpo.valor_bruto}`)
+
+console.log('OK: pricing usa a data_frete final — Santos Brasil pos-cutoff = 740 mesmo com correcao da Regra 8')


### PR DESCRIPTION
## Problema
Fretes Santos Brasil pos-cutoff (>=2026-04-22) saiam ~50% a **680** em vez de **740** (~R\$9k subfaturado, crescendo todo dia). DPW quase imune (2 errados / 167).

## Causa raiz
Em `applyBusinessRules` a precificacao (`valor_bruto`/`comissao`/`valor_liquido`) rodava **antes** da Regra 8. A Regra 8 corrige uma data OCR fora de range pro timestamp da mensagem. Quando o OCR lia uma data pre-cutoff fora de range:
1. frete precificado a 680 (data ainda pre-cutoff)
2. Regra 8 corrige a data pra pos-cutoff
3. resultado: data nova (>=22/04) + valor velho (680)

Santos Brasil tem OCR de data pior -> ~50% batia o caminho ruim; DPW le mais limpo -> quase imune. Explica o split ~50/50 e a imunidade do DPW.

## Fix
Mover `valor_bruto`/`comissao`/`valor_liquido` pra **depois** da Regra 8, usando a `data_frete` FINAL. `pedagio` fica onde estava (depende so do terminal, nao da data).

## Teste
`services/test-pricing-date-order.js` reproduz o cenario (data pre-cutoff fora de range + Santos Brasil + msg pos-cutoff) e assere `valor_bruto=740`, `comissao=170`. Passa com o fix.

## Escopo
So o **fix de codigo** (passo 1/3 - estanca a sangria). Passos 2 e 3 (backfill dos NAO pagos + lista dos pagos subfaturados pro Thiago) sao operacao de dados, feitos separado depois do fix validado em prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)